### PR TITLE
Fix variable replacement with falsy values

### DIFF
--- a/src/utils/replace.test.ts
+++ b/src/utils/replace.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "@jest/globals";
+import { replaceVariables } from "./replace.js";
+
+describe("replaceVariables", () => {
+  test("replaces variables including falsy values", () => {
+    const template = "a={{a}}, b={{b}}, c={{c}}";
+    const result = replaceVariables(template, { a: 1, b: 0, c: "" });
+    expect(result).toBe("a=1, b=0, c=");
+  });
+
+  test("leaves unknown placeholders intact", () => {
+    const template = "foo={{bar}}";
+    const result = replaceVariables(template, {});
+    expect(result).toBe("foo={{bar}}");
+  });
+});

--- a/src/utils/replace.ts
+++ b/src/utils/replace.ts
@@ -5,8 +5,9 @@ export function replaceVariables(
 ): string {
   const pattern = placeholderStyle === "{{}}" ? /\{\{(.*?)\}\}/g : /\{(.*?)\}/g;
   input = input.replace(pattern, (match, group) => {
-    if (variables[group]) {
-      return variables[group];
+    if (Object.prototype.hasOwnProperty.call(variables, group)) {
+      const value = variables[group];
+      return value === undefined || value === null ? "" : String(value);
     }
     return match;
   });


### PR DESCRIPTION
## Summary
- ensure replaceVariables handles falsy values like `0` or ""
- add unit tests for replaceVariables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841188bace0832eba80a0fe8cf23426