### PR TITLE
Fix delimiter spelling in consoleWriter

### DIFF
--- a/src/recorder/consoleWriter.ts
+++ b/src/recorder/consoleWriter.ts
@@ -231,7 +231,7 @@ function body(
   values(level, data, options);
 }
 
-const deliminator = "    ";
+const delimiter = "    ";
 
 function values(
   level: LogLevel,
@@ -251,14 +251,14 @@ function values(
   }
   data.forEach((d) => {
     if (typeof d === "string") {
-      console.log(b(`${deliminator}${d}`));
+      console.log(b(`${delimiter}${d}`));
       return;
     }
     for (const [key, value] of Object.entries(d)) {
       let v = JSON.stringify(value, truncator(options.truncate), "\t");
       const printable = `${key}: ${v}`
         .split("\n")
-        .map((line) => deliminator + line)
+        .map((line) => delimiter + line)
         .join("\n");
       console.log(b(printable));
     }


### PR DESCRIPTION
## Summary
- rename `deliminator` constant to `delimiter`
- update all references in `consoleWriter`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841ae5620b4832ea076c3a9c7b5cbf7